### PR TITLE
Turn on org-indent in a chunk, when it is globally enabled

### DIFF
--- a/poly-org.el
+++ b/poly-org.el
@@ -47,6 +47,11 @@
       (or (cdr (assoc lang org-src-lang-modes))
           lang))))
 
+(defun poly-org--maybe-enable-org-indent (_)
+  (when (and (boundp 'org-indent-mode)
+             org-startup-indented)
+    (org-indent-mode)))
+
 (define-hostmode poly-org-hostmode
   :mode 'org-mode
   :protect-syntax nil
@@ -59,6 +64,7 @@
   :head-matcher "^[ \t]*#\\+begin_src .*\n"
   :tail-matcher "^[ \t]*#\\+end_src"
   :head-adjust-face nil
+  :init-functions '(poly-org--maybe-enable-org-indent)
   :mode-matcher #'poly-org-mode-matcher
   :indent-offset org-edit-src-content-indentation)
 


### PR DESCRIPTION
Otherwise source code would be misaligned with other text around.
There is a case when org-indent is disabled globally, i.e. `org-startup-indented` is `nil`, but org-indent is enabled per file via org-header `#+STARTUP: indent`.
I don't know how to handle this case, since I can't get local variables of the host buffer from the hook `poly-org--maybe-enable-org-indent`.