### PR TITLE
Add inner mode for latex environments

### DIFF
--- a/poly-org.el
+++ b/poly-org.el
@@ -41,7 +41,7 @@
 (define-obsolete-variable-alias 'pm-host/org 'poly-org-hostmode "v0.2")
 (define-obsolete-variable-alias 'pm-inner/org 'poly-org-innermode "v0.2")
 
-(defun poly-org-mode-matcher ()
+(defun poly-org-mode-src-matcher ()
   (when (re-search-forward "#\\+begin_src +\\([^ \t\n]+\\)" (point-at-eol) t)
     (let ((lang (match-string-no-properties 1)))
       (or (cdr (assoc lang org-src-lang-modes))
@@ -66,22 +66,30 @@ Used in :switch-buffer-functions slot."
   :protect-syntax nil
   :protect-font-lock nil)
 
-(define-auto-innermode poly-org-innermode
+(define-auto-innermode poly-org-src-innermode
   :fallback-mode 'host
   :head-mode 'host
   :tail-mode 'host
   :head-matcher "^[ \t]*#\\+begin_src .*\n"
   :tail-matcher "^[ \t]*#\\+end_src"
-  :mode-matcher #'poly-org-mode-matcher
+  :mode-matcher #'poly-org-mode-src-matcher
   :head-adjust-face nil
   :switch-buffer-functions '(poly-org-convey-src-block-params-to-inner-modes)
   :body-indent-offset 'org-edit-src-content-indentation
   :indent-offset 'org-edit-src-content-indentation)
 
+(define-innermode poly-org-latex-innermode
+  :fallback-mode 'host
+  :head-mode 'host
+  :tail-mode 'host
+  :mode 'latex-mode
+  :head-matcher "^[ \t]*\\\\begin{.*}\n"
+  :tail-matcher "^[ \t]*\\\\end{.*}\n")
+
 ;;;###autoload  (autoload 'poly-org-mode "poly-org")
 (define-polymode poly-org-mode
   :hostmode 'poly-org-hostmode
-  :innermodes '(poly-org-innermode)
+  :innermodes '(poly-org-src-innermode poly-org-latex-innermode)
   (setq-local org-src-fontify-natively nil)
   (make-local-variable 'polymode-move-these-minor-modes-from-old-buffer)
   (push 'org-indent-mode polymode-move-these-minor-modes-from-old-buffer))


### PR DESCRIPTION
This enables latex-mode for raw latex environments, which are common where we want exports to md/html to also have the latex equation. E.g.

```
foo bar baz

\begin{equation}
  x^y
\end{equation}
```