### PR TITLE
General blocks support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.el diff=elisp

--- a/poly-org.el
+++ b/poly-org.el
@@ -43,9 +43,15 @@
 
 (defun poly-org-mode-matcher ()
   (when (re-search-forward
-         ;; in fact, it does not have to be src or example
-         ;; it seems like org would accept any #+begin_pazuzu
-         (rx "#+begin_" (or "src" "example")
+         ;; there is no exhaustive list of block names in org-mode source
+         ;; the most complete list would be
+         ;; the default value of org-structure-template-alist
+         ;; we took everything listed there into account
+         ;; it is known however there's begin_latex and who knows what else
+         ;; that should be given yet more special treatment
+         ;; Last but not least, we repeat this list thrice in this file
+         ;; which is horrendous and something has to be done about it
+         (rx "#+begin_" (or "src" "example" "export")
              (+ " ") (group (+ (not (or " " "\t" "\n")))))
          (point-at-eol) t)
     (let ((lang (match-string-no-properties 1)))
@@ -78,11 +84,11 @@ Used in :switch-buffer-functions slot."
   ;; the following is incorrect:
   ;; tail-matcher actually depends on head-matcher
   :head-matcher (rx line-start (* (or " " "\t"))
-                    "#+begin_" (or "src" "example")
+                    "#+begin_" (or "src" "example" "export")
                     " " (* not-newline)
                     "\n")
   :tail-matcher (rx line-start (* (or " " "\t"))
-                    "#+end_" (or "src" "example"))
+                    "#+end_" (or "src" "example" "export"))
   :mode-matcher #'poly-org-mode-matcher
   :head-adjust-face nil
   :switch-buffer-functions '(poly-org-convey-src-block-params-to-inner-modes)

--- a/poly-org.el
+++ b/poly-org.el
@@ -2,7 +2,7 @@
 ;;
 ;; Author: Vitalie Spinu
 ;; Maintainer: Vitalie Spinu
-;; Copyright (C) 2013-2018 Vitalie Spinu
+;; Copyright (C) 2013-2020 Vitalie Spinu
 ;; Version: 0.2
 ;; Package-Requires: ((emacs "25") (polymode "0.2"))
 ;; URL: https://github.com/polymode/poly-org


### PR DESCRIPTION
Currently, only `src` blocks are recognised by poly-org-innermode. Org by default applies e.g. lang's font-lock to the blocks with headers `example lang`. I use `example lisp` and `example elisp` extensively. There's rarely a need to edit them in my case but not in general case. Regardless, with poly-org not recognising them, it breaks the default font-lock. This patch intends to fix that.

It's not just `src` and `example` though. Org is extremely vague on this part of its syntax. I added yet another label but that was not enough to make it complete. See in-code commentary for details; at least it's better than `src` only. Providing a complete solution will likely take indefinite amount  of time because there's no spec and it looks like everyone is fine with that.

Another problem is, `:tail-matcher` should depend on `:head-matcher`. I did not try to look into polymode and see if this is supported. If it's not, it should; rx syntax will likely make this actually tractable, in contrast to string regexps.

I extended all three entries of `src` but I don't know if I should have.

String regexps are replaced with `rx` regexps due to my personal tastes. I'm not good at any of the two syntaxes and I don't see any comparison function in elisp to check for equivalence but a couple of days of regular use suggests that everything works fine.

I added `.gitattributes` setting because this particular diff is affected by bad default heuristic in a chunk in `poly-org.el`.