### PR TITLE
ensure case insensitive search on mode-matcher

### DIFF
--- a/poly-org.el
+++ b/poly-org.el
@@ -43,10 +43,11 @@
 (define-obsolete-variable-alias 'pm-inner/org 'poly-org-innermode "v0.2")
 
 (defun poly-org-mode-matcher ()
-  (when (re-search-forward "#\\+begin_\\(src\\|example\\|export\\) +\\([^ \t\n]+\\)" (point-at-eol) t)
-    (let ((lang (match-string-no-properties 2)))
-      (or (cdr (assoc lang org-src-lang-modes))
-          lang))))
+  (let ((case-fold-search t))
+    (when (re-search-forward "#\\+begin_\\(src\\|example\\|export\\) +\\([^ \t\n]+\\)" (point-at-eol) t)
+      (let ((lang (match-string-no-properties 2)))
+        (or (cdr (assoc lang org-src-lang-modes))
+            lang)))))
 
 (defvar ess-local-process-name)
 (defun poly-org-convey-src-block-params-to-inner-modes (_ this-buf)


### PR DESCRIPTION
I usually use upper case letters for block header/tails in org mode. 

It turns out in some cases poly-org-mode-matcher can be called with case-fold-search set to nil and it wasn't able to determine the mode from the upper case #+BEGIN_SRC.

In my case smartparens mode was setting case-fold-search to nil, but I assume there can be other cases.