### PR TITLE
Respect `:lexical t` in elisp src blocks

### DIFF
--- a/poly-org.el
+++ b/poly-org.el
@@ -62,7 +62,14 @@ Used in :switch-buffer-functions slot."
           (let ((proc (buffer-local-value 'ess-local-process-name
                                           (get-buffer session))))
             (with-current-buffer this-buf
-              (setq-local ess-local-process-name proc)))))))))
+              (setq-local ess-local-process-name proc)))))))
+   ((derived-mode-p 'emacs-lisp-mode)
+    (with-current-buffer (pm-base-buffer)
+      (let ((params (nth 2 (org-babel-get-src-block-info t))))
+        (with-current-buffer this-buf
+          (setq-local lexical-binding
+                      ;; TODO: Improve this criterion
+                      (string-equal "t" (cdr (assq :lexical params))))))))))
 
 (define-hostmode poly-org-hostmode
   :mode 'org-mode


### PR DESCRIPTION
Often, it is preferrable to `eval-defun` (`C-M-x`) with point inside the src block rather than move point to the src block boundary and `org-ctrl-c-ctrl-c` (`C-c C-c`).  However, currently `eval-defun` in the indirect buffer does not respect `lexical-binding` which makes `eval-defun` unusable e.g. whenever closures are used.  The patch conveys the `:lexical t` src block parameter in blocks with mode derived from `emacs-lisp-mode`.