### PR TITLE
Delete superfluous space before autoload

### DIFF
--- a/poly-org.el
+++ b/poly-org.el
@@ -108,7 +108,7 @@ Used in :switch-buffer-functions slot."
               (append '(org-element--cache-after-change)
                       polymode-run-these-after-change-functions-in-other-buffers)))
 
- ;;;###autoload
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.org\\'" . poly-org-mode))
 
 (provide 'poly-org)


### PR DESCRIPTION
See #50 for more info; details pasted down here for simplicify

I installed (using `use-package`) `poly-org-mode` and was surprised that it wasn't automatically activating itself when editing `org-mode` files.

I checked `auto-mode-alist`, and noticed that it had not registered itself. There is an [autoload cookie](https://github.com/polymode/poly-org/blob/5ca02279a4e6f5025cd2c7b1196058d3e74dc5d5/poly-org.el#L111-L112) that should have triggered this, but there's a typo: it has a leading space and thus is not a valid autoload cookie (the default regexp begins `^;;;` and thus doesn't match). 

```
 ;;;###autoload
(add-to-list 'auto-mode-alist '("\\.org\\'" . poly-org-mode))
```
(the space before `;;;###autoload` is hard to see, but it's there) An added clue is that github's emacs-lisp syntax highlighter colors these cookie differently than other cookies in the file