### PR TITLE
[Fix #49] Make inner modes inherit org-mode

### DIFF
--- a/poly-org.el
+++ b/poly-org.el
@@ -115,6 +115,8 @@ Used in :switch-buffer-functions slot."
               (append '(org-element--cache-after-change)
                       polymode-run-these-after-change-functions-in-other-buffers)))
 
+(pm-around-advice 'org-element-at-point #'polymode-with-current-base-buffer)
+
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.org\\'" . poly-org-mode))
 


### PR DESCRIPTION
Calls to org functions such as org-element-at-point throw an error if the major mode does not inherit org as a parent. 
This patch fixes this issue by creating a function poly-org-enable-modes that creates mode+org-mode for use as an inner mode. The mode+org-mode is the same as mode, but also inherits org as a parent.